### PR TITLE
Fix responsive option to include required collapse class

### DIFF
--- a/lib/rails_bootstrap_navbar/view_helpers.rb
+++ b/lib/rails_bootstrap_navbar/view_helpers.rb
@@ -113,7 +113,7 @@ module RailsBootstrapNavbar
 	  end
 
 	  def responsive_div(&block)
-			content_tag(:div, :class => "nav-collapse", &block)
+			content_tag(:div, :class => "nav-collapse collapse", &block)
 	  end
 
 	  def is_active?(path)

--- a/spec/lib/rails_bootstrap_navbar/view_helpers_spec.rb
+++ b/spec/lib/rails_bootstrap_navbar/view_helpers_spec.rb
@@ -240,7 +240,7 @@ RESPONSIVE_NAVBAR = <<-HTML
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </a>
-      <div class="nav-collapse">
+      <div class="nav-collapse collapse">
       </div>
     </div>
   </div>
@@ -256,7 +256,7 @@ RESPONSIVE_NAVBAR_WITH_BLOCK = <<-HTML
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </a>
-      <div class="nav-collapse">
+      <div class="nav-collapse collapse">
 				<p>Passing a block</p>
       </div>
     </div>


### PR DESCRIPTION
Bootstrap requires .collapse on nav-collapse div to work properly
